### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,11 @@ This project is a collaborative effort driven by the open-source community:
 
 ### 🐧 Linux / WSL
 1.  Open a terminal in the project folder.
-2.  Make scripts executable:
-    ```bash
-    chmod +x install.sh run.sh
-    ```
-3.  Run the installer:
+2.  Run the installer:
     ```bash
     ./install.sh
     ```
-4.  Start the app:
+3.  Start the app:
     ```bash
     ./run.sh
     ```


### PR DESCRIPTION
Tiny little suggestion / PR and hope you don't find it petty:

Remove bits about chmod +x, as the execute bit is already set on these files (confirmed in commit 53ed492).

Ideally, it should work just like on Windows: clone the repo and run ./install.sh. The uv engine will be downloaded if not present and handle the rest. The only major difference left is that ffmpeg remains a manual prerequisite on Linux due to the variety of distribution-specific package managers.