### PR TITLE
v5.4: Gemma 4 + Qwen3-VL support, correct chat-handler selection, dependency/wheel fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ walkthrough.md
 
 # Local Orchestration
 scripts/
+
+# Claude Code local settings
+.claude/settings.local.json

--- a/Install.bat
+++ b/Install.bat
@@ -90,11 +90,11 @@ if "%RESET_VENV%"=="true" (
 )
 
 if not exist ".venv" (
-    :: --managed-python doesn't exist on uv 0.5.21 (what this bootstrap
-    :: leaves in place when uv is already on PATH). --python-preference
-    :: only-managed is the 0.5.21 equivalent: forces uv's own downloaded
-    :: interpreter so the venv matches our pinned llama-cpp-python wheel
-    :: ABI and never touches whatever Python is already on the user's system.
+    REM --managed-python doesn't exist on uv 0.5.21 (what this bootstrap
+    REM leaves in place when uv is already on PATH). --python-preference
+    REM only-managed is the 0.5.21 equivalent: forces uv's own downloaded
+    REM interpreter so the venv matches our pinned llama-cpp-python wheel
+    REM ABI and never touches whatever Python is already on the user's system.
     uv venv .venv --python 3.10 --seed --python-preference only-managed --link-mode hardlink
 )
 

--- a/Install.bat
+++ b/Install.bat
@@ -226,7 +226,21 @@ echo [CHECK] Verifying GPU Acceleration...
 :: reports False unconditionally regardless of whether CUDA actually loads.
 :: Load the backends the same way Llama.__init__ does and check for a real
 :: GPU device instead.
-call .venv\Scripts\python -c "import ctypes; from pathlib import Path; import llama_cpp.llama_cpp as llama_cpp_lib; from llama_cpp._ggml import ggml_backend_load_all_from_path, ggml_backend_dev_by_type; lib_dir = Path(llama_cpp_lib.__file__).resolve().parent / 'lib'; ggml_backend_load_all_from_path(ctypes.c_char_p(str(lib_dir).encode('utf-8'))); print(f'>>> GPU Offload Supported: {bool(ggml_backend_dev_by_type(1))}')"
+::
+:: llama_cpp prints a wall of native "loaded library from ..." / "optional
+:: API unavailable" / ggml backend-init noise on every fresh process. Send
+:: it to a log file and only surface the one result line; dump the full
+:: log if that line is missing (real failure). Avoids piping the quote-heavy
+:: python -c string through a nested for /f command (the exact class of
+:: cmd.exe parser fragility that caused issue #13).
+set "GPU_CHECK_LOG=%TEMP%\avc_gpu_check_%RANDOM%.log"
+call .venv\Scripts\python -c "import ctypes; from pathlib import Path; import llama_cpp.llama_cpp as llama_cpp_lib; from llama_cpp._ggml import ggml_backend_load_all_from_path, ggml_backend_dev_by_type; lib_dir = Path(llama_cpp_lib.__file__).resolve().parent / 'lib'; ggml_backend_load_all_from_path(ctypes.c_char_p(str(lib_dir).encode('utf-8'))); print(f'>>> GPU Offload Supported: {bool(ggml_backend_dev_by_type(1))}')" > "%GPU_CHECK_LOG%" 2>&1
+findstr /C:">>> GPU Offload Supported:" "%GPU_CHECK_LOG%"
+if errorlevel 1 (
+    echo WARNING: Llama GPU check failed to run
+    type "%GPU_CHECK_LOG%"
+)
+del "%GPU_CHECK_LOG%" >nul 2>&1
 
 echo.
 echo ======================================================================

--- a/Install.bat
+++ b/Install.bat
@@ -220,7 +220,13 @@ uv pip install transformers accelerate huggingface_hub --link-mode hardlink
 
 echo.
 echo [CHECK] Verifying GPU Acceleration...
-call .venv\Scripts\python -c "from llama_cpp import llama_supports_gpu_offload; print(f'>>> GPU Offload Supported: {llama_supports_gpu_offload()}')"
+:: llama_supports_gpu_offload() checks a static build-time flag that no
+:: longer means anything on GGML_BACKEND_DL wheels (CUDA ships as a
+:: separate dynamically-loaded backend, not compiled into llama.dll) - it
+:: reports False unconditionally regardless of whether CUDA actually loads.
+:: Load the backends the same way Llama.__init__ does and check for a real
+:: GPU device instead.
+call .venv\Scripts\python -c "import ctypes; from pathlib import Path; import llama_cpp.llama_cpp as llama_cpp_lib; from llama_cpp._ggml import ggml_backend_load_all_from_path, ggml_backend_dev_by_type; lib_dir = Path(llama_cpp_lib.__file__).resolve().parent / 'lib'; ggml_backend_load_all_from_path(ctypes.c_char_p(str(lib_dir).encode('utf-8'))); print(f'>>> GPU Offload Supported: {bool(ggml_backend_dev_by_type(1))}')"
 
 echo.
 echo ======================================================================
@@ -251,9 +257,9 @@ exit /b 0
 :: Sets: WHEEL_FILE, WIN_WHEEL_URL, WIN_WHEEL_SHA256
 :: --------------------------------------------------------------------
 :resolve_wheel
-set "WIN_WHEEL_URL=https://github.com/cyberbol/AI-Video-Clipper-LoRA/releases/download/v5.3-llama-deps/llama_cpp_python-0.3.26+cu128-cp310-cp310-win_amd64.whl"
-set "WIN_WHEEL_SHA256=f3e8512dd6e80f847189420bdeba657cc45d38d42cf025e2bababaa9f5188013"
-set "WHEEL_FILE=llama_cpp_python-0.3.26+cu128-cp310-cp310-win_amd64.whl"
+set "WIN_WHEEL_URL=https://github.com/cyberbol/AI-Video-Clipper-LoRA/releases/download/v5.4-llama-deps/llama_cpp_python-0.3.44+cu128-cp310-cp310-win_amd64.whl"
+set "WIN_WHEEL_SHA256=96291f3af2ec492f6625f69b40b22a6996d53198f4d4739e9f55f9030817d128"
+set "WHEEL_FILE=llama_cpp_python-0.3.44+cu128-cp310-cp310-win_amd64.whl"
 
 set "MAJOR_CAP="
 for /f "tokens=1 delims=." %%a in ('nvidia-smi --query-gpu=compute_cap --format=csv^,noheader 2^>nul') do set "MAJOR_CAP=%%a"

--- a/Install.bat
+++ b/Install.bat
@@ -1,6 +1,6 @@
 @echo off
 setlocal EnableDelayedExpansion
-:: AI Video Clipper & LoRA Captioner - Windows Installer (v5.0 Staging)
+:: AI Video Clipper & LoRA Captioner - Windows Installer (v5.4)
 
 TITLE AI Clipper Installer - UV Edition
 color 0B

--- a/Install.bat
+++ b/Install.bat
@@ -90,7 +90,12 @@ if "%RESET_VENV%"=="true" (
 )
 
 if not exist ".venv" (
-    uv venv .venv --python 3.10 --seed --managed-python --link-mode hardlink
+    :: --managed-python doesn't exist on uv 0.5.21 (what this bootstrap
+    :: leaves in place when uv is already on PATH). --python-preference
+    :: only-managed is the 0.5.21 equivalent: forces uv's own downloaded
+    :: interpreter so the venv matches our pinned llama-cpp-python wheel
+    :: ABI and never touches whatever Python is already on the user's system.
+    uv venv .venv --python 3.10 --seed --python-preference only-managed --link-mode hardlink
 )
 
 :: --------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ For developers needing to support new CUDA versions or custom model architecture
 ## 📜 Changelog
 
 <details open>
+<summary><b>v5.4 - Gemma 4 & Qwen3-VL Support</b></summary>
+
+* **Gemma 4 12B and Qwen3-VL 8B** are now available as vision models, auto-downloaded the same way as the existing GGUF models. Gemma 4 is now the default.
+* The vision engine now selects the correct model-specific chat handler instead of a one-size-fits-all LLaVA template - fixes garbled/truncated captions that showed up on these newer models under the old generic handler.
+* Cleaned up the model picker (dropped the `GGUF:`/`Transformer:` label prefixes, reordered so the recommended models sort first).
+* Bumped the attested `llama-cpp-python` wheels to v0.3.44+cu128 to pick up current Gemma/Qwen support.
+* Assorted install/runtime hardening: fixed a silent CPU-fallback bug in GPU detection, a `cmd.exe` parser crash in `Install.bat`'s venv setup, and pinned `transformers`/`compressed-tensors` versions together to keep FP8 audio loading working.
+</details>
+
+<details>
 <summary><b>v5.2 - Blackwell Detection & Installer Hardening</b></summary>
 
 * **Fixed RTX 5090/Blackwell wheel detection on Windows:** a cmd.exe parser bug in `Install.bat` was silently falling back to the standard `llama-cpp-python` wheel on Blackwell GPUs instead of the CUDA-optimized build, with no error shown ([#13](https://github.com/cyberbol/AI-Video-Clipper-LoRA/issues/13)).

--- a/app.py
+++ b/app.py
@@ -38,6 +38,7 @@ except ImportError:
     HAS_TKINTER = False
 import logging
 import shutil
+import subprocess
 
 # Suppress Streamlit's "missing ScriptRunContext" warning in threads
 logging.getLogger("streamlit.runtime.scriptrunner_utils.script_run_context").setLevel(logging.ERROR)
@@ -171,6 +172,21 @@ def clear_vram():
     gc.collect()
     torch.cuda.empty_cache()
 
+def log_vram(label):
+    """Diagnostic: actual GPU-wide VRAM in use per nvidia-smi, not just
+    what torch.cuda tracks - catches non-PyTorch allocations (llama.cpp's
+    own CUDA buffers, CTranslate2, etc.) that torch's own counters miss."""
+    try:
+        nvidia_smi = shutil.which("nvidia-smi") or "/usr/lib/wsl/lib/nvidia-smi"
+        out = subprocess.check_output(
+            [nvidia_smi, "--query-gpu=memory.used,memory.total", "--format=csv,noheader,nounits"],
+            timeout=5,
+        )
+        used, total = out.decode().strip().split(", ")
+        print(f"🩺 VRAM [{label}]: {used}MiB / {total}MiB used (GPU-wide)")
+    except Exception as e:
+        print(f"🩺 VRAM [{label}]: readout failed ({e})")
+
 # --- 5. MODEL LOADERS (MODULARIZED) ---
 def load_vision_engine():
     """Unified loading using VisionEngine class"""
@@ -268,6 +284,7 @@ if app_mode == "🎥 Video Auto-Clipper":
             if 'audio_engine' in st.session_state and st.session_state['audio_engine']:
                 st.session_state['audio_engine'].clear()
             clear_vram()
+            log_vram("after Phase 0 clean slate")
 
             # === PHASE 1: WHISPER X ===
             print(f"\n🚀 [Phase 1] Speech Analysis (WhisperX) started on {video_path}...")
@@ -336,6 +353,7 @@ if app_mode == "🎥 Video Auto-Clipper":
                 with st.spinner("Ensuring Audio Model (Downloader Active)..."):
                     download_model(SELECTED_AUDIO_ID, MODELS_DIR, log_callback=status_box.text)
 
+                log_vram("before Audio Engine load")
                 a_engine = load_audio_engine()
                 # Ensure loaded
                 if not a_engine.model:

--- a/app.py
+++ b/app.py
@@ -16,6 +16,13 @@ except ImportError:
     # Basic fallbacks if patches.py is missing
     pass
 
+# Silence transformers' lazy-module __path__ deprecation spam (fires on every
+# vision/audio model load, once per deprecated image-processor alias - has to
+# be set before transformers gets imported anywhere else, including
+# transitively via whisperx/pyannote).
+import transformers
+transformers.utils.logging.set_verbosity_error()
+
 import streamlit as st
 import whisperx
 from moviepy import VideoFileClip, AudioFileClip

--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 # --------------------------------------------------------------------------------
-# AI Video Clipper & LoRA Captioner (v5.0 Staging)
+# AI Video Clipper & LoRA Captioner (v5.4)
 # 🏆 CREDITS: Cyberbol (Logic), FNGarvin (Engine), WildSpeaker (5090 Fix)
 # --------------------------------------------------------------------------------
 
@@ -66,9 +66,9 @@ os.makedirs(MODELS_DIR, exist_ok=True)
 os.environ["HF_HOME"] = MODELS_DIR
 
 # --- 3. UI CONFIG ---
-st.set_page_config(page_title="AI Clipper v5.0", layout="wide")
+st.set_page_config(page_title="AI Clipper v5.4", layout="wide")
 st.title("👁️🐧👂 AI Video Clipper & LoRA Captioner")
-st.markdown("v5.0 | **[Cyberbol](https://github.com/cyberbol/)** (Project Creator) | **[FNG](https://github.com/FNGarvin/)** (Engine) | **WildSpeaker** (Has a 5090!)")
+st.markdown("v5.4 | **[Cyberbol](https://github.com/cyberbol/)** (Project Creator) | **[FNG](https://github.com/FNGarvin/)** (Engine) | **WildSpeaker** (Has a 5090!)")
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -86,38 +86,53 @@ app_mode = st.sidebar.selectbox("Choose Mode:", [
 ])
 
 # --- MODEL SELECTION (Radio Buttons) ---
-model_options = {
-    "GGUF: Gemma-3-12B (Next-Gen, 4-bit)": {
+# Dict insertion order = dropdown order (Python dicts + Streamlit selectbox
+# both preserve it), so the hardcoded entries are split around the
+# auto-discovery block below to land newly-scanned local models between
+# Gemma 4 and Qwen3-VL rather than at the end.
+KNOWN_GGUF_MODELS = {
+    "Gemma 4 12B (Q5_K_XL)": {
         "backend": "gguf",
-        "repo": "unsloth/gemma-3-12b-it-GGUF",
-        "model": "gemma-3-12b-it-IQ4_XS.gguf",
+        "repo": "unsloth/gemma-4-12b-it-GGUF",
+        "model": "gemma-4-12b-it-UD-Q5_K_XL.gguf",
         "projector": "mmproj-F16.gguf"
     },
-    "GGUF: Qwen3-VL-8B-Instruct (Q4_K_M)": {
+    "Qwen3-VL 8B Instruct (Q4_K_M)": {
         "backend": "gguf",
         "repo": "Qwen/Qwen3-VL-8B-Instruct-GGUF",
         "model": "Qwen3VL-8B-Instruct-Q4_K_M.gguf",
         "projector": "mmproj-Qwen3VL-8B-Instruct-Q8_0.gguf"
     },
-    "Transformer: Qwen2-VL-7B (High Quality)": {
-        "backend": "transformers",
-        "id": "Qwen/Qwen2-VL-7B-Instruct"
+    "Gemma 3 12B (4-bit)": {
+        "backend": "gguf",
+        "repo": "unsloth/gemma-3-12b-it-GGUF",
+        "model": "gemma-3-12b-it-IQ4_XS.gguf",
+        "projector": "mmproj-F16.gguf"
     },
-    "Transformer: Qwen2-VL-2B (Fast)": {
-        "backend": "transformers",
-        "id": "Qwen/Qwen2-VL-2B-Instruct"
-    }
 }
+
+model_options = {"Gemma 4 12B (Q5_K_XL)": KNOWN_GGUF_MODELS["Gemma 4 12B (Q5_K_XL)"]}
 
 # Auto-Discovery
 local_ggufs = scan_local_gguf_models(MODELS_DIR)
 # Filter duplicates
-existing_ggufs = [m["model"] for m in model_options.values() if m.get("backend") == "gguf"]
+existing_ggufs = [m["model"] for m in KNOWN_GGUF_MODELS.values()]
 for label, config in local_ggufs.items():
     if config["model"] not in existing_ggufs:
         model_options[label] = config
 
-model_label = st.sidebar.selectbox("Vision Model:", list(model_options.keys()), index=2)
+model_options["Qwen3-VL 8B Instruct (Q4_K_M)"] = KNOWN_GGUF_MODELS["Qwen3-VL 8B Instruct (Q4_K_M)"]
+model_options["Gemma 3 12B (4-bit)"] = KNOWN_GGUF_MODELS["Gemma 3 12B (4-bit)"]
+model_options["Qwen2-VL 2B (Fast)"] = {
+    "backend": "transformers",
+    "id": "Qwen/Qwen2-VL-2B-Instruct"
+}
+model_options["Qwen2-VL 7B (High Quality)"] = {
+    "backend": "transformers",
+    "id": "Qwen/Qwen2-VL-7B-Instruct"
+}
+
+model_label = st.sidebar.selectbox("Vision Model:", list(model_options.keys()), index=0)
 SELECTED_MODEL = model_options[model_label]
 SELECTED_VISION_ID = SELECTED_MODEL.get("id", SELECTED_MODEL.get("model")) # Fallback ID
 
@@ -404,7 +419,7 @@ if app_mode == "🎥 Video Auto-Clipper":
 
             video_f.close(); 
             clear_vram()
-            st.success("✅ DONE! v5.0 Pipeline Finished.")
+            st.success("✅ DONE! v5.4 Pipeline Finished.")
             end_ts = time.time(); mins, secs = divmod(end_ts - start_ts, 60)
             timer_placeholder.success(f"⏱️ Total Time: {int(mins)}m {int(secs)}s")
 
@@ -645,10 +660,6 @@ else:
         finally:
             if temp_img_dir and os.path.exists(temp_img_dir):
                 shutil.rmtree(temp_img_dir)
-
-st.markdown("---")
-st.markdown("<div style='text-align: center'><a href='https://github.com/cyberbol/AI-Video-Clipper-LoRA'>An Open Source Project</a></div>", unsafe_allow_html=True)
-
 
 st.markdown("---")
 st.markdown("<div style='text-align: center'><a href='https://github.com/cyberbol/AI-Video-Clipper-LoRA'>An Open Source Project</a></div>", unsafe_allow_html=True)

--- a/app.py
+++ b/app.py
@@ -231,7 +231,7 @@ def select_folder_dialog():
     return folder_path
 
 # =================================================================================================
-# MODE 1: VIDEO AUTO-CLIPPER (v5.0 Merged Logic)
+# MODE 1: VIDEO AUTO-CLIPPER
 # =================================================================================================
 if app_mode == "🎥 Video Auto-Clipper":
     project_name = st.text_input("Project Name (Optional)", value="")

--- a/install.sh
+++ b/install.sh
@@ -113,7 +113,13 @@ else
     fi
 
     if [ ! -d ".venv" ]; then
-        uv venv .venv --python 3.10 --seed --managed-python --link-mode hardlink
+        # --managed-python doesn't exist on uv 0.5.21 (what this bootstrap
+        # leaves in place when uv is already on PATH, e.g. inside the
+        # container image). --python-preference only-managed is the 0.5.21
+        # equivalent: forces uv's own downloaded interpreter so the venv
+        # matches our pinned llama-cpp-python wheel ABI and never touches
+        # whatever Python happens to already be on the user's system.
+        uv venv .venv --python 3.10 --seed --python-preference only-managed --link-mode hardlink
     fi
     source .venv/bin/activate
 fi

--- a/install.sh
+++ b/install.sh
@@ -226,10 +226,23 @@ lib_dir = Path(llama_cpp_lib.__file__).resolve().parent / 'lib'
 ggml_backend_load_all_from_path(ctypes.c_char_p(str(lib_dir).encode('utf-8')))
 print(f'>>> GPU Offload Supported: {bool(ggml_backend_dev_by_type(1))}')
 "
+    # llama_cpp prints a wall of native "loaded library from ..." /
+    # "optional API unavailable" / ggml backend-init noise on every fresh
+    # process (see modules/vision_engine.py for the equivalent runtime fix) -
+    # this is a one-shot subprocess so that fix doesn't reach it. Capture
+    # everything and surface only the one line we actually care about;
+    # dump the full output if that line is missing (real failure).
     if [ "$USE_SYSTEM" = true ]; then
-        python3 -c "$GPU_CHECK_PY" || echo "WARNING: Llama check failed"
+        GPU_CHECK_OUTPUT=$(python3 -c "$GPU_CHECK_PY" 2>&1)
     else
-        .venv/bin/python -c "$GPU_CHECK_PY" || echo "WARNING: Llama check failed"
+        GPU_CHECK_OUTPUT=$(.venv/bin/python -c "$GPU_CHECK_PY" 2>&1)
+    fi
+    GPU_CHECK_RESULT=$(echo "$GPU_CHECK_OUTPUT" | grep ">>> GPU Offload Supported:")
+    if [ -n "$GPU_CHECK_RESULT" ]; then
+        echo "$GPU_CHECK_RESULT"
+    else
+        echo "WARNING: Llama GPU check failed to run"
+        echo "$GPU_CHECK_OUTPUT"
     fi
 else
     echo "[INFO] Skipping GPU Verification (Build Mode)"

--- a/install.sh
+++ b/install.sh
@@ -72,13 +72,13 @@ resolve_wheel() {
     fi
 
     if [ "$PY_VER" == "3.10" ]; then
-        LINUX_WHEEL_URL="https://github.com/cyberbol/AI-Video-Clipper-LoRA/releases/download/v5.3-llama-deps/llama_cpp_python-0.3.26+cu128-cp310-cp310-linux_x86_64.whl"
-        LINUX_WHEEL_SHA256="821cc8244f36a9595b465aa51d109ab3b24e1b8fd911a655678786365f4be65b"
-        WHEEL_FILE="llama_cpp_python-0.3.26+cu128-cp310-cp310-linux_x86_64.whl"
+        LINUX_WHEEL_URL="https://github.com/cyberbol/AI-Video-Clipper-LoRA/releases/download/v5.4-llama-deps/llama_cpp_python-0.3.44+cu128-cp310-cp310-linux_x86_64.whl"
+        LINUX_WHEEL_SHA256="6cf11a799a54b29aebc2f3d4a436d61844516a475045c130fee74814852f075f"
+        WHEEL_FILE="llama_cpp_python-0.3.44+cu128-cp310-cp310-linux_x86_64.whl"
     elif [ "$PY_VER" == "3.12" ]; then
-        LINUX_WHEEL_URL="https://github.com/cyberbol/AI-Video-Clipper-LoRA/releases/download/v5.3-llama-deps/llama_cpp_python-0.3.26+cu128-cp312-cp312-linux_x86_64.whl"
-        LINUX_WHEEL_SHA256="86f0b0e6b010b38c0316e296b871e622c2b154e20d737b0c528d8dd17aa4e303"
-        WHEEL_FILE="llama_cpp_python-0.3.26+cu128-cp312-cp312-linux_x86_64.whl"
+        LINUX_WHEEL_URL="https://github.com/cyberbol/AI-Video-Clipper-LoRA/releases/download/v5.4-llama-deps/llama_cpp_python-0.3.44+cu128-cp312-cp312-linux_x86_64.whl"
+        LINUX_WHEEL_SHA256="baec17ea25494ab79c998befba14a2f5960c17838dc27453d7c10b1da222f6fa"
+        WHEEL_FILE="llama_cpp_python-0.3.44+cu128-cp312-cp312-linux_x86_64.whl"
     else
         echo "[ERROR] Unsupported Python Version for GPU Acceleration: $PY_VER. Only 3.10 and 3.12 supported."
         # Fail hard to prevent broken installs
@@ -211,10 +211,25 @@ if [ "$SKIP_GPU_CHECK" != "true" ]; then
         fi
     fi
 
+    # llama_supports_gpu_offload() checks a static build-time flag that no
+    # longer means anything on GGML_BACKEND_DL wheels (CUDA ships as a
+    # separate dynamically-loaded backend, not compiled into libllama.so) -
+    # it reports False unconditionally regardless of whether CUDA actually
+    # loads. Load the backends the same way Llama.__init__ does and check
+    # for a real GPU device instead.
+    GPU_CHECK_PY="
+import ctypes
+from pathlib import Path
+import llama_cpp.llama_cpp as llama_cpp_lib
+from llama_cpp._ggml import ggml_backend_load_all_from_path, ggml_backend_dev_by_type
+lib_dir = Path(llama_cpp_lib.__file__).resolve().parent / 'lib'
+ggml_backend_load_all_from_path(ctypes.c_char_p(str(lib_dir).encode('utf-8')))
+print(f'>>> GPU Offload Supported: {bool(ggml_backend_dev_by_type(1))}')
+"
     if [ "$USE_SYSTEM" = true ]; then
-        python3 -c "from llama_cpp import llama_supports_gpu_offload; print(f'>>> GPU Offload Supported: {llama_supports_gpu_offload()}')" || echo "WARNING: Llama check failed"
+        python3 -c "$GPU_CHECK_PY" || echo "WARNING: Llama check failed"
     else
-        .venv/bin/python -c "from llama_cpp import llama_supports_gpu_offload; print(f'>>> GPU Offload Supported: {llama_supports_gpu_offload()}')" || echo "WARNING: Llama check failed"
+        .venv/bin/python -c "$GPU_CHECK_PY" || echo "WARNING: Llama check failed"
     fi
 else
     echo "[INFO] Skipping GPU Verification (Build Mode)"

--- a/modules/vision_engine.py
+++ b/modules/vision_engine.py
@@ -6,6 +6,7 @@
 
 import os
 import gc
+import json
 import torch
 import base64
 from threading import Thread
@@ -27,9 +28,16 @@ try:
     with contextlib.redirect_stdout(io.StringIO()):
         from llama_cpp import Llama
         from llama_cpp.llama_chat_format import Llava15ChatHandler
+        try:
+            from llama_cpp.llama_chat_format import Gemma3ChatHandler, Gemma4ChatHandler, Qwen3VLChatHandler
+        except ImportError:
+            # Older llama-cpp-python builds may lack these model-specific
+            # handlers - fall back to the generic LLaVA-1.5 template for them.
+            Gemma3ChatHandler = Gemma4ChatHandler = Qwen3VLChatHandler = None
 except ImportError:
     Llama = None
     Llava15ChatHandler = None
+    Gemma3ChatHandler = Gemma4ChatHandler = Qwen3VLChatHandler = None
 
 IMPORT_ERROR = None
 try:
@@ -121,6 +129,23 @@ class GGUFVisionEngine:
         self.llm = None
         self.chat_handler = None
 
+    @staticmethod
+    def _resolve_chat_handler(model_file):
+        """Picks the model-specific chat handler (correct chat template +
+        stop tokens) instead of always falling back to the generic
+        Llava15ChatHandler, which feeds every model a USER:/ASSISTANT:
+        format it was never trained on - the direct cause of Gemma 4's
+        <|channel>thought<channel|> leaking into output and Qwen3-VL
+        returning empty completions."""
+        name = model_file.lower()
+        if Gemma4ChatHandler and "gemma-4" in name:
+            return Gemma4ChatHandler, {"enable_thinking": False}
+        if Gemma3ChatHandler and "gemma-3" in name:
+            return Gemma3ChatHandler, {}
+        if Qwen3VLChatHandler and "qwen3vl" in name:
+            return Qwen3VLChatHandler, {"image_min_tokens": 1024}
+        return Llava15ChatHandler, {}
+
     def load(self, log_callback=None):
         if Llama is None:
             raise ImportError("llama-cpp-python is missing. Install with CUDA support.")
@@ -145,10 +170,11 @@ class GGUFVisionEngine:
             if not os.path.exists(p_path): raise FileNotFoundError(f"Projector file missing: {p_path}")
 
         if p_path:
+            handler_cls, handler_kwargs = self._resolve_chat_handler(self.model_file)
             try:
-                self.chat_handler = Llava15ChatHandler(clip_model_path=p_path, verbose=False)
+                self.chat_handler = handler_cls(mmproj_path=p_path, verbose=False, **handler_kwargs)
             except Exception as e:
-                print(f"⚠️ Failed to init LlavaChatHandler: {e}")
+                print(f"⚠️ Failed to init {handler_cls.__name__}: {e}")
                 self.chat_handler = None
         else:
             self.chat_handler = None
@@ -209,7 +235,12 @@ class GGUFVisionEngine:
         content_list.append({"type": "text", "text": final_prompt})
 
         messages = [
-            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "system", "content": (
+                "You are a helpful assistant. Respond with a single flowing "
+                "paragraph of plain prose only - no JSON, no markdown code "
+                "fences, no headings, and no step-by-step reasoning or "
+                "<think> tags."
+            )},
             {"role": "user", "content": content_list}
         ]
         
@@ -262,9 +293,40 @@ class GGUFVisionEngine:
             with open(path, "rb") as f: return base64.b64encode(f.read()).decode("utf-8")
 
     def _post_process(self, text, trigger):
+        print(f"🔍 RAW MODEL OUTPUT (pre-strip):\n{text!r}\n")
+        text = self._strip_thinking_and_json(text)
         text = text.replace("**", "").replace("##", "").strip()
         if trigger and trigger.lower() not in text.lower():
             text = f"{trigger}, {text}"
+        return text
+
+    def _strip_thinking_and_json(self, text):
+        """Defensive cleanup for models (Qwen3-VL GGUF quants in particular)
+        that ignore the system prompt's plain-prose instruction and answer
+        with <think> blocks and/or a JSON object, sometimes truncated
+        mid-field by max_tokens."""
+        import re
+
+        text = re.sub(r"<think(?:ing)?>.*?</think(?:ing)?>", "", text, flags=re.IGNORECASE | re.DOTALL)
+        text = re.sub(r"^```(?:json)?\s*", "", text.strip())
+        text = re.sub(r"```\s*$", "", text).strip()
+
+        if text.startswith("{"):
+            try:
+                parsed = json.loads(text)
+            except json.JSONDecodeError:
+                # Truncated by max_tokens mid-field - recover whichever
+                # complete "key": "value" pairs exist rather than showing
+                # raw JSON syntax.
+                values = re.findall(r'"\s*:\s*"([^"]*)"', text)
+                if values:
+                    text = " ".join(v.strip() for v in values if v.strip())
+            else:
+                if isinstance(parsed, dict):
+                    text = " ".join(str(v).strip() for v in parsed.values() if str(v).strip())
+                else:
+                    text = str(parsed)
+
         return text
 
     def clear(self):
@@ -389,9 +451,40 @@ class TransformersVisionEngine:
             return self._post_process(output_text, trigger)
 
     def _post_process(self, text, trigger):
+        print(f"🔍 RAW MODEL OUTPUT (pre-strip):\n{text!r}\n")
+        text = self._strip_thinking_and_json(text)
         text = text.replace("**", "").replace("##", "").strip()
         if trigger and trigger.lower() not in text.lower():
             text = f"{trigger}, {text}"
+        return text
+
+    def _strip_thinking_and_json(self, text):
+        """Defensive cleanup for models (Qwen3-VL GGUF quants in particular)
+        that ignore the system prompt's plain-prose instruction and answer
+        with <think> blocks and/or a JSON object, sometimes truncated
+        mid-field by max_tokens."""
+        import re
+
+        text = re.sub(r"<think(?:ing)?>.*?</think(?:ing)?>", "", text, flags=re.IGNORECASE | re.DOTALL)
+        text = re.sub(r"^```(?:json)?\s*", "", text.strip())
+        text = re.sub(r"```\s*$", "", text).strip()
+
+        if text.startswith("{"):
+            try:
+                parsed = json.loads(text)
+            except json.JSONDecodeError:
+                # Truncated by max_tokens mid-field - recover whichever
+                # complete "key": "value" pairs exist rather than showing
+                # raw JSON syntax.
+                values = re.findall(r'"\s*:\s*"([^"]*)"', text)
+                if values:
+                    text = " ".join(v.strip() for v in values if v.strip())
+            else:
+                if isinstance(parsed, dict):
+                    text = " ".join(str(v).strip() for v in parsed.values() if str(v).strip())
+                else:
+                    text = str(parsed)
+
         return text
 
     def clear(self):
@@ -407,7 +500,16 @@ def scan_local_gguf_models(models_dir):
     if not os.path.exists(models_dir): return discovered
     
     for root, dirs, files in os.walk(models_dir):
-        ggufs = [f for f in files if f.endswith(".gguf") and not f.lower().startswith("mmproj-")]
+        # mtp-* files are multi-token-prediction/draft weights that ride
+        # alongside a real model+projector pair (e.g. Gemma 4's
+        # mtp-gemma-4-12b-it.gguf) - not a loadable model on their own, so
+        # they'd otherwise show up as a bogus duplicate entry.
+        ggufs = [
+            f for f in files
+            if f.endswith(".gguf")
+            and not f.lower().startswith("mmproj-")
+            and not f.lower().startswith("mtp-")
+        ]
         projectors = [f for f in files if f.lower().startswith("mmproj-") and f.endswith(".gguf")]
         
         if ggufs and projectors:

--- a/modules/vision_engine.py
+++ b/modules/vision_engine.py
@@ -440,8 +440,9 @@ class TransformersVisionEngine:
             full_text = ""
             for new_text in streamer:
                 full_text += new_text
-                stream_callback(self._post_process(full_text, trigger))
-            
+                # Stream raw accumulated text; only post-process once at the end
+                stream_callback(full_text)
+
             thread.join()
             return self._post_process(full_text, trigger)
         else:

--- a/modules/vision_engine.py
+++ b/modules/vision_engine.py
@@ -144,13 +144,20 @@ class GGUFVisionEngine:
         else:
             self.chat_handler = None
 
-        self.llm = Llama(
-            model_path=m_path,
-            chat_handler=self.chat_handler,
-            n_ctx=self.n_ctx,  # Configurable
-            n_gpu_layers=self.n_gpu_layers, # Configurable
-            verbose=False    # Keep checking stdout clean
-        )
+        try:
+            self.llm = Llama(
+                model_path=m_path,
+                chat_handler=self.chat_handler,
+                n_ctx=self.n_ctx,  # Configurable
+                n_gpu_layers=self.n_gpu_layers, # Configurable
+                verbose=False    # Keep checking stdout clean
+            )
+        except Exception as e:
+            if log_callback: log_callback(f"❌ Load Failed: {e}")
+            self.llm = None
+            self.chat_handler = None
+            gc.collect()
+            raise RuntimeError(f"Failed to load {self.model_file}: {e}") from None
         if log_callback: log_callback("✅ GGUF Engine Ready.")
 
     def caption(self, content_path, content_type, trigger, instruction, gen_config=None, stream_callback=None):
@@ -291,7 +298,15 @@ class TransformersVisionEngine:
             if log_callback: log_callback("✅ Transformers Engine Ready.")
         except Exception as e:
             if log_callback: log_callback(f"❌ Load Failed: {e}")
-            raise e
+            # Re-raising `e` directly would keep its original traceback alive,
+            # which pins every GPU tensor from_pretrained had already loaded
+            # before the failure - leaving VRAM stuck until the whole process
+            # exits. Raise a fresh exception instead so cleanup actually frees it.
+            self.model = None
+            self.processor = None
+            gc.collect()
+            torch.cuda.empty_cache()
+            raise RuntimeError(f"Failed to load {self.model_id}: {e}") from None
 
     def caption(self, content_path, content_type, trigger, instruction, gen_config=None, stream_callback=None):
         if not self.model: raise RuntimeError("Engine not loaded.")

--- a/modules/vision_engine.py
+++ b/modules/vision_engine.py
@@ -16,8 +16,17 @@ import tempfile
 
 # --- Lazy Imports for Heavy Libraries ---
 try:
-    from llama_cpp import Llama
-    from llama_cpp.llama_chat_format import Llava15ChatHandler
+    # llama_cpp prints "optional API unavailable" warnings via a bare print()
+    # (not the logging module, so no verbosity flag reaches it) for every
+    # ctypes symbol lookup that misses on this platform - fires once, here,
+    # at import time. Redirecting stdout is the only way to suppress it;
+    # ImportError still propagates normally since redirect_stdout doesn't
+    # swallow exceptions.
+    import contextlib
+    import io
+    with contextlib.redirect_stdout(io.StringIO()):
+        from llama_cpp import Llama
+        from llama_cpp.llama_chat_format import Llava15ChatHandler
 except ImportError:
     Llama = None
     Llava15ChatHandler = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,12 @@ description = "AI Video Clipper & LoRA Captioner"
 authors = [{ name = "Cyberbol" }]
 dependencies = [
     "qwen-vl-utils",
-    "accelerate",
-    "transformers>=4.45.0",
+    # transformers/accelerate/huggingface_hub/compressed-tensors pinned together:
+    # newer compressed-tensors mismatches the weight_scale key naming baked into
+    # mlinmg/Qwen-2-Audio-Instruct-dynamic-fp8, silently discarding the checkpoint's
+    # real FP8 dequant scales in favor of random re-init (garbage audio captions).
+    "accelerate==1.13.0",
+    "transformers==5.8.0",
     "streamlit",
     "moviepy",
     "pillow<11.0",
@@ -19,7 +23,7 @@ dependencies = [
     "tqdm",
     "pyannote.audio==3.4.0",
     "speechbrain==1.0.3",
-    "huggingface_hub",
-    "compressed-tensors",
+    "huggingface_hub==1.14.0",
+    "compressed-tensors==0.15.0.1",
 ]
 requires-python = ">=3.10"

--- a/run.sh
+++ b/run.sh
@@ -20,14 +20,19 @@ done
 # Set up local model paths
 export HF_HOME="./models"
 export TORCH_HOME="./models"
-export NVIDIA_LIBS=$(python3 -c 'import site, os, glob; paths = [glob.glob(os.path.join(p, "nvidia/*/lib")) for p in site.getsitepackages()]; print(":".join([p for sub in paths for p in sub]))' 2>/dev/null)
-export LD_LIBRARY_PATH=$NVIDIA_LIBS:$LD_LIBRARY_PATH
 export KMP_DUPLICATE_LIB_OK=TRUE
 
-# Activate environment
+# Activate environment BEFORE computing NVIDIA_LIBS - it must reflect the
+# venv's own torch/nvidia packages, not whatever (or nothing) system python3
+# happens to have. Getting this backwards means llama.cpp's dynamic CUDA
+# backend silently fails to dlopen (missing libcudart/libcublas/libnccl) and
+# every GGUF vision model falls back to CPU with no error at all.
 if [ -f ".venv/bin/activate" ]; then
     source .venv/bin/activate
 fi
+
+export NVIDIA_LIBS=$(python3 -c 'import site, os, glob; paths = [glob.glob(os.path.join(p, "nvidia/*/lib")) for p in site.getsitepackages()]; print(":".join([p for sub in paths for p in sub]))' 2>/dev/null)
+export LD_LIBRARY_PATH=$NVIDIA_LIBS:$LD_LIBRARY_PATH
 
 echo "Starting Streamlit on $HOST:$PORT..."
 streamlit run app.py --server.port $PORT --server.address $HOST

--- a/tests/test_gpu_detect.bat
+++ b/tests/test_gpu_detect.bat
@@ -30,7 +30,7 @@ set "PATH=%SCRIPT_DIR%fixtures;%PATH%"
 set "PASS_COUNT=0"
 set "FAIL_COUNT=0"
 
-set "EXPECT_WHEEL=llama_cpp_python-0.3.26+cu128-cp310-cp310-win_amd64.whl"
+set "EXPECT_WHEEL=llama_cpp_python-0.3.44+cu128-cp310-cp310-win_amd64.whl"
 
 echo ======================================================================
 echo   WHEEL RESOLUTION REGRESSION TEST (Install.bat --detect-only)

--- a/tests/test_gpu_detect.sh
+++ b/tests/test_gpu_detect.sh
@@ -29,9 +29,9 @@ FAIL_COUNT=0
 
 PY_VER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null || echo "3.10")
 if [ "$PY_VER" == "3.10" ]; then
-    EXPECT_WHEEL="llama_cpp_python-0.3.26+cu128-cp310-cp310-linux_x86_64.whl"
+    EXPECT_WHEEL="llama_cpp_python-0.3.44+cu128-cp310-cp310-linux_x86_64.whl"
 else
-    EXPECT_WHEEL="llama_cpp_python-0.3.26+cu128-cp312-cp312-linux_x86_64.whl"
+    EXPECT_WHEEL="llama_cpp_python-0.3.44+cu128-cp312-cp312-linux_x86_64.whl"
 fi
 
 echo "======================================================================"


### PR DESCRIPTION
## Summary
- Add Gemma 4 12B and Qwen3-VL 8B as selectable GGUF vision models, using the same auto-download flow as the existing models
- Fix vision engine to select the model-specific llama-cpp-python chat handler (`Gemma4ChatHandler`, `Gemma3ChatHandler`, `Qwen3VLChatHandler`) instead of always using the generic `Llava15ChatHandler` - this was the actual root cause of Gemma 4 leaking `<|channel>thought<channel|>` tokens into captions and Qwen3-VL returning empty completions
- Make Gemma 4 the default model, clean up the model dropdown labels (drop the `GGUF:`/`Transformer:` prefixes) and ordering
- Fix per-token debug-log spam on the Transformers streaming path (`_post_process` was re-running on every token instead of once at the end)
- Add `log_vram()` diagnostic checkpoints around the audio/vision phases to help track down a still-open, non-reproducing VRAM issue
- Pin `transformers`/`compressed-tensors` together (newer `compressed-tensors` mismatches this project's FP8 checkpoint's `weight_scale` key naming)
- Bump `llama-cpp-python` wheel pin to v0.3.44+cu128 (current Gemma/Qwen support), fix a silent CPU-fallback bug in the GPU capability check and in `run.sh`'s library path ordering
- Fix a `cmd.exe` parser crash in `Install.bat`'s venv creation block
- Clean up remaining v5.0-era branding/comments, and rewrite the v5.4 changelog entry to lead with the new model support

## Test plan
- [x] Verified Gemma 4 and Qwen3-VL both download and caption correctly (no more leaked reasoning tokens / empty completions)
- [x] Verified Qwen2-VL 7B (Transformers backend) still works
- [x] Verified VRAM is released between phases (Whisper, vision, audio) via isolated load/caption/clear cycles
- [x] Verified wheel-CI recipe now matches the actual v0.3.44 wheels being shipped
- [ ] Sourcery review

## Summary by Sourcery

Add Gemma 4 and Qwen3-VL vision model support, improve captioning behavior and VRAM diagnostics, and harden installation and GPU detection around updated llama-cpp-python and transformer dependencies.

New Features:
- Expose Gemma 4 12B and Qwen3-VL 8B as selectable auto-downloaded GGUF vision models and make Gemma 4 the default.
- Add VRAM logging checkpoints around audio and vision phases to capture GPU-wide memory usage during the pipeline.

Bug Fixes:
- Select model-specific llama-cpp-python chat handlers for Gemma 3/4 and Qwen3-VL to prevent leaked thinking tokens and empty captions.
- Strip <think> blocks, JSON wrappers, and markdown fences from model outputs to ensure clean prose captions.
- Prevent transformers-based vision captions from being re-post-processed on every streamed token by only applying post-processing once at completion.
- Ensure failed Transformers and GGUF loads free GPU memory by resetting state and re-raising sanitized exceptions.
- Exclude mtp-* GGUF draft weights from local model auto-discovery to avoid bogus duplicate entries.
- Silence noisy transformers and llama-cpp import-time logs that previously polluted stdout.
- Fix GPU detection to check actual dynamically loaded CUDA backends rather than a stale build flag so GGUF models no longer silently fall back to CPU.
- Fix Install.bat’s venv creation and GPU check flow to avoid cmd.exe parser crashes and better surface GPU support status.

Enhancements:
- Rework the system prompt and caption post-processing to prefer single-paragraph plain prose without JSON or explicit reasoning markup.
- Refine the model dropdown labels and ordering, removing backend prefixes and surfacing recommended models first.
- Make GGUF load failures log a clear error message and reset engine state before raising a RuntimeError.
- Adjust run.sh to activate the virtualenv before computing NVIDIA library paths so CUDA backends resolve against the correct environment.

Build:
- Update Linux and Windows install scripts and tests to pin llama-cpp-python wheels to v0.3.44+cu128 for supported Gemma/Qwen features.
- Change uv venv creation on Linux and Windows to use --python-preference only-managed instead of the unsupported --managed-python flag.

CI:
- Update GPU detection regression tests to expect the new llama-cpp-python 0.3.44 wheel filenames.

Documentation:
- Add a v5.4 changelog entry highlighting Gemma 4 and Qwen3-VL support, captioning fixes, and installer hardening.
- Update app and installer branding to v5.4 to match the new release.

Tests:
- Adjust GPU detection test fixtures to assert the updated v5.4 wheel names for Linux and Windows.